### PR TITLE
at-spi2-atk 2.34.2: x11_gui_rebuilds

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/at-spi2-core-feedstock/pr4/e34c647

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/at-spi2-core-feedstock/pr4/e34c647

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -5,7 +5,6 @@
 set -e
 
 meson setup builddir \
-    -D enable_docs=false \
     --prefix=$PREFIX \
     --libdir=$PREFIX/lib  \
     --wrap-mode=nofallback

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,10 @@
-# Prior to conda-forge, Copyright 2014-2019 Peter Williams and collaborators.
-# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
-
 {% set name = "at-spi2-atk" %}
 {% set version = "2.34.2" %}
-{% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
+{% set version_majmin = "'.'.join(version.split('.', 2)[:2])" %}
 {% set sha256 = "901323cee0eef05c01ec4dee06c701aeeca81a314a7d60216fa363005e27f4f0" %}
 
+# Prior to conda-forge, Copyright 2014-2019 Peter Williams and collaborators.
+# This file is licensed under a 3-clause BSD license; see LICENSE.txt.
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -15,13 +14,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
-  skip: True  # [win]
+  number: 2
+  skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('at-spi2-atk', max_pin='x') }}
   missing_dso_whitelist:  # [linux]
     - $RPATH/libpthread.so.0  # [linux]
     - $RPATH/libc.so.6  # [linux]
+
 requirements:
   build:
     - meson
@@ -29,17 +29,17 @@ requirements:
     - pkg-config
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
-    - {{ cdt('libx11-devel') }}  # [linux]
-    - {{ cdt('libxi-devel') }}  # [linux]
-    - {{ cdt('libxfixes-devel') }}  # [linux]
-    - {{ cdt('libxtst-devel') }}  # [linux and not ppc64le]
-    - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
   host:
     - at-spi2-core
     - atk
     - dbus
     - glib
     - gobject-introspection
+    - xorg-libx11
+    - xorg-libxi
+    - xorg-libxfixes
+    - xorg-libxtst
+    - xorg-xproto
   run:
     # this line can be removed when dbus gets exported properly
     - {{ pin_compatible('dbus') }}
@@ -54,7 +54,7 @@ about:
   license: LGPL-2.1-or-later
   license_family: LGPL
   license_file: COPYING
-  summary: 'bridge for AT-SPI and ATK accessibility technologies'
+  summary: bridge for AT-SPI and ATK accessibility technologies
   description: |
     This package includes libatk-bridge, a library that bridges ATK to the new
     D-Bus based AT-SPI, as well as a corresponding module for gtk+ 2.x. Gtk+ 3.x

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,16 +30,12 @@ requirements:
     - pthread-stubs  # [linux]
     - {{ compiler('c') }}
   host:
+    # xorg-* packages brought through at-spi2-core.
     - at-spi2-core
     - atk
     - dbus
     - glib
     - gobject-introspection
-    - xorg-libx11
-    - xorg-libxi
-    - xorg-libxfixes
-    - xorg-libxtst
-    - xorg-xorgproto
   run:
     # this line can be removed when dbus gets exported properly
     - {{ pin_compatible('dbus') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,7 +47,7 @@ requirements:
 test:
   commands:
     - test -f $PREFIX/include/at-spi2-atk/2.0/atk-bridge.h  # [unix]
-    - test -f $PREFIX/lib/libatk-bridge-2.0${SHLIB_EXT}  # [unix]
+    - test -f $PREFIX/lib/libatk-bridge-2.0${SHLIB_EXT}     # [unix]
 
 about:
   home: http://www.gtk.org/

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: 901323cee0eef05c01ec4dee06c701aeeca81a314a7d60216fa363005e27f4f0
 
 build:
-  number: 2
+  number: 1
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('at-spi2-atk', max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set name = "at-spi2-atk" %}
-{% set version = "2.34.2" %}
-{% set version_majmin = "'.'.join(version.split('.', 2)[:2])" %}
-{% set sha256 = "901323cee0eef05c01ec4dee06c701aeeca81a314a7d60216fa363005e27f4f0" %}
-
 # Prior to conda-forge, Copyright 2014-2019 Peter Williams and collaborators.
 # This file is licensed under a 3-clause BSD license; see LICENSE.txt.
+
+{% set name = "at-spi2-atk" %}
+{% set version = "2.34.2" %}
+{% set version_majmin = '.'.join(version.split('.', 2)[:2]) %}
+
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: http://ftp.gnome.org/pub/gnome/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
-  sha256: {{ sha256 }}
+  url: https://download.gnome.org/sources/{{ name }}/{{ version_majmin }}/{{ name }}-{{ version }}.tar.xz
+  sha256: 901323cee0eef05c01ec4dee06c701aeeca81a314a7d60216fa363005e27f4f0
 
 build:
   number: 2
@@ -39,7 +39,7 @@ requirements:
     - xorg-libxi
     - xorg-libxfixes
     - xorg-libxtst
-    - xorg-xproto
+    - xorg-xorgproto
   run:
     # this line can be removed when dbus gets exported properly
     - {{ pin_compatible('dbus') }}


### PR DESCRIPTION

# at-spi2-atk 2.34.2: x11_gui_rebuilds

**Destination channel:** main

### Links

- [PKG-7773](https://anaconda.atlassian.net/browse/PKG-7773)
- [Upstream repository](https://gitlab.gnome.org/GNOME/at-spi2-atk)

### Explanation of changes:

- Bump the build number to 1
- Fix source URL to use https
- Remove an obsolete meson option (`enable_docs=false`)
- Add `xorg-xorgproto` to host dependencies

### Notes:

- It's an automated migration/rebuild for the `x11_gui_rebuilds` group:

```
  x11_gui_rebuilds:
    stages:
    - stage: 0
      packages:
      - tk
      - libxkbcommon
      - pango
      - at-spi2-core
      - at-spi2-atk
      - tktable
    - stage: 1
      packages:
      - gtk2
      - gtk3
      - gstreamer
      - harfbuzz
      - cairo
    - stage: 2
      packages:
      - qtbase
      - qtsvg
      - qtimageformats
      - qt5compat
      - qtshadertools
      - qttranslations
    - stage: 3
      packages:
      - qtwebchannel
      - qtwebsockets
      - qtdeclarative
      - qttools
    - stage: 4
      packages:
      - pyqt
      - pyside6
      - wxpython
      - pycairo
    - stage: 5
      packages:
      - glew
      - graphviz
      - jasper
      - gobject-introspection
      - librsvg
    - stage: 6
      packages:
      - qtwebengine
      - vtk
      - opencv
      - poppler
    - stage: 7
      packages:
      - portaudio
      - texlive-core
      - seaborn
```


[PKG-7773]: https://anaconda.atlassian.net/browse/PKG-7773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ